### PR TITLE
Add 'const' to LoggerPtr& parameter in logHelper

### DIFF
--- a/include/cvs/logger/argumentpreprocessor.hpp
+++ b/include/cvs/logger/argumentpreprocessor.hpp
@@ -7,7 +7,7 @@ namespace cvs::logger {
 template <typename T>
 struct ArgumentPreprocessor {
   template <typename Arg>
-  static auto exec(std::shared_ptr<spdlog::logger>&, spdlog::level::level_enum, Arg&& arg) {
+  static auto exec(const std::shared_ptr<spdlog::logger>&, spdlog::level::level_enum, Arg&& arg) {
     return std::forward<Arg>(arg);
   }
 };

--- a/include/cvs/logger/logging.hpp
+++ b/include/cvs/logger/logging.hpp
@@ -24,7 +24,7 @@ bool      configureLogger(spdlog::logger&, cvs::common::Config&);
 namespace detail {
 
 template <typename... Args>
-void logHelper(LoggerPtr&                logger,
+void logHelper(const LoggerPtr&          logger,
                spdlog::level::level_enum lvl,
                spdlog::string_view_t     fmt,
                Args&&... args) {

--- a/include/cvs/logger/opencvhelper.hpp
+++ b/include/cvs/logger/opencvhelper.hpp
@@ -14,7 +14,7 @@ void configureLoggerAndOpenCVHelper(spdlog::logger& logger, cvs::common::Config&
 
 template <>
 struct ArgumentPreprocessor<cv::Mat> {
-  static std::string exec(std::shared_ptr<spdlog::logger>&,
+  static std::string exec(const std::shared_ptr<spdlog::logger>&,
                           spdlog::level::level_enum,
                           const cv::Mat& arg);
 

--- a/src/opencvhelper.cpp
+++ b/src/opencvhelper.cpp
@@ -54,9 +54,9 @@ namespace cvs::logger {
 std::map<std::string, ArgumentPreprocessor<cv::Mat>::LoggerInfo>
     ArgumentPreprocessor<cv::Mat>::save_info;
 
-std::string ArgumentPreprocessor<cv::Mat>::exec(std::shared_ptr<spdlog::logger>& logger,
-                                                spdlog::level::level_enum        lvl,
-                                                const cv::Mat&                   arg) {
+std::string ArgumentPreprocessor<cv::Mat>::exec(const std::shared_ptr<spdlog::logger>& logger,
+                                                spdlog::level::level_enum              lvl,
+                                                const cv::Mat&                         arg) {
   auto& info = save_info[logger->name()];
 
   if (lvl < info.lvl.value_or(defaultSave()))


### PR DESCRIPTION
Сделал параметр `logger` функции `logHelper` константным, чтобы иметь возможность вызвать логгер в константных методах.